### PR TITLE
Fix typo in distance print statement

### DIFF
--- a/Sliding_Window_with_1D_DSS/04_Scattering_Transform.py
+++ b/Sliding_Window_with_1D_DSS/04_Scattering_Transform.py
@@ -52,7 +52,7 @@ for i in range(0, len(tr_1.data) - segment_len_samples + 1, step_samples):
     distance_all.append(i * distance_per_sample)
 
 print("========================== Confirm the distances ==========================")
-print(f"Origianl Distance: {config.TOTAL_DISTANCE_KM*len(file_list)} km")
+print(f"Original Distance: {config.TOTAL_DISTANCE_KM*len(file_list)} km")
 print(f"Distance: {distance_all[-1]} km")
 
 # Run the scattering transform


### PR DESCRIPTION
## Summary
- correct a spelling mistake in the scattering transform script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fe6e9ff78832192223f9ebcf51d2e